### PR TITLE
Move cite outside link (for better okular support)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -267,11 +267,11 @@ export class Url2Cite {
 						Superscript([cite]),
 					];
 				else if (outputFormat === "normal") {
-					return Link(
-						attr,
-						[...inline, Space(), cite],
-						[url, targetTitle],
-					);
+					return [
+						Link(attr, [...inline], [url, targetTitle]),
+						Space(),
+						cite,
+					];
 				}
 				throw Error(`Unknown output format ${outputFormat}`);
 			}


### PR DESCRIPTION
Currently, when viewing the generated PDFs in `okular`, the citations are covered by the links, preventing jumping to the bibliography:

![Screenshot from 2023-06-09 10-40-22](https://github.com/phiresky/pandoc-url2cite/assets/95857153/28aec3b6-f1d6-4cbb-9a80-8ab333ce2abe)

This PR moves the (`normal`-mode) citations outside the links, so that `okular` is not confused:

![Screenshot from 2023-06-09 10-40-34](https://github.com/phiresky/pandoc-url2cite/assets/95857153/e49eb896-55eb-4ff4-959d-d340c3ef2ec1)

